### PR TITLE
补丁：下载视频图片文件名变更；下功loading换位置

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -292,7 +292,6 @@ function addDlBtn(footer) {
                     }
                 }
             }
-            console.log('downloadList=',downloadList)
             handleDownloadList(downloadList, dlBtn);
         }
     });
@@ -332,7 +331,6 @@ function sAddDlBtn(footer) {
                 response = httpGet('https://weibo.com/ajax/statuses/show?id=' + mid);
             }
             const resJson = JSON.parse(response);
-            // console.log(resJson);
             let status = resJson;
             if (resJson.hasOwnProperty('retweeted_status')) {
                 status = resJson.retweeted_status;
@@ -347,14 +345,12 @@ function sAddDlBtn(footer) {
             const text = status.text_raw;
             let downloadList = [];
             if (footer.parentElement.getElementsByTagName('video').length > 0) {
-                // console.log('download video');
                 if (resJson.hasOwnProperty('page_info')) {
                     downloadList = downloadList.concat(handleVideo(resJson.page_info.media_info, 1, userName,
                         userId, postId, postUid, 1, postTime, text, downloadFileName));
                 }
             }
             if (picInfos) {
-                // console.log('download images');
                 let index = 0;
                 let padLength = Object.entries(picInfos).length.toString().length;
                 let countNum = Object.keys(picInfos).length;
@@ -365,7 +361,6 @@ function sAddDlBtn(footer) {
                 }
             }
             if (mixMediaInfo && mixMediaInfo.items) {
-                // console.log('mix media');
                 let index = 0;
                 let padLength = Object.entries(mixMediaInfo.items).length.toString().length;
                 let countNum = Object.keys(mixMediaInfo.items).length;
@@ -387,7 +382,6 @@ function sAddDlBtn(footer) {
     aInLi.appendChild(dlBtn);
     dlBtnLi.appendChild(dlBtn);
     footer.firstChild.appendChild(dlBtnLi);
-    // console.log('added download button');
 }
 
 function bodyMouseOver(event) {
@@ -470,6 +464,5 @@ document.addEventListener('DOMContentLoaded', function() {
   `;
     document.head.appendChild(style);
 
-    // console.log('我被执行了！');
     document.body.addEventListener('mouseover', bodyMouseOver);
 });


### PR DESCRIPTION
您好

      有幸在github上看到您的代码，很满足我的需求，只是有一些个人使用习惯，自己试着改了一下，以下是我做的变动。

      改动：
      1、原来在下载时命名是一串字母数据组合，我将它改成了由“微博昵称 发布 - 微博内容”组成的新文件名，并且在当前微博中多个图片或视频时，在每个文件名后面加上“ 空格+数字序号”做为区分；
      2、原loading界面会覆盖整个页面，我只能等当前这个任务下载完后才能再下另一个微博的内容。我将它移动到了下载按钮的右边，点击下载时才显示，下载完成后隐藏；

      另外，我在下载live视频时发现，下载下来的视频文件后缀没有".mov"，我给补上了；


      以上是我做的修改，希望您别介意。这是我第一次在gitHub上提交我修改过的代码，如果有打扰还请见谅。


                                                                                                                                                                祝生活愉快
